### PR TITLE
Add list command

### DIFF
--- a/honkfish.go
+++ b/honkfish.go
@@ -9,16 +9,16 @@ import (
 	"sort"
 )
 
-type SlackResponse struct {
+type slackResponse struct {
 	ResponseType string `json:"response_type"`
 	Text         string `json:"text"`
 }
 
-type Alphabetically []string
+type alphabetically []string
 
-func (s Alphabetically) Len() int           { return len(s) }
-func (s Alphabetically) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s Alphabetically) Less(i, j int) bool { return len(s[i]) < len(s[j]) }
+func (s alphabetically) Len() int           { return len(s) }
+func (s alphabetically) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s alphabetically) Less(i, j int) bool { return len(s[i]) < len(s[j]) }
 
 /*
 	Translation map from honks to the boat's behaviour
@@ -68,14 +68,14 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func translateHonks(honks string) SlackResponse {
+func translateHonks(honks string) slackResponse {
 	translation, found := dictionary[honks]
 
 	if !found {
 		translation = "Failed to convert honks. Perhaps you misheard?"
 	}
 
-	response := SlackResponse{
+	response := slackResponse{
 		ResponseType: "in_channel",
 		Text:         fmt.Sprintf("Translation: %s", translation),
 	}
@@ -83,8 +83,8 @@ func translateHonks(honks string) SlackResponse {
 	return response
 }
 
-func usageText() SlackResponse {
-	response := SlackResponse{
+func usageText() slackResponse {
+	response := slackResponse{
 		ResponseType: "ephemeral",
 		Text:         "Usage:\n`/honkfish honk pause HONK`\nhonk = short honk\nHONK = long honk\npause = a gap between honks",
 	}
@@ -92,7 +92,7 @@ func usageText() SlackResponse {
 	return response
 }
 
-func honksList() SlackResponse {
+func honksList() slackResponse {
 	formattedHonks := "Honks:"
 
 	var honks []string
@@ -101,13 +101,13 @@ func honksList() SlackResponse {
 		honks = append(honks, key)
 	}
 
-	sort.Sort(Alphabetically(honks))
+	sort.Sort(alphabetically(honks))
 
 	for _, honk := range honks {
 		formattedHonks += fmt.Sprintf("\n_%s_ -> %s", honk, dictionary[honk])
 	}
 
-	response := SlackResponse{
+	response := slackResponse{
 		ResponseType: "ephemeral",
 		Text:         formattedHonks,
 	}
@@ -116,7 +116,7 @@ func honksList() SlackResponse {
 }
 
 // Handles JSON marshalling and sending response to client
-func sendResponse(w http.ResponseWriter, response SlackResponse) {
+func sendResponse(w http.ResponseWriter, response slackResponse) {
 	j, err := json.Marshal(response)
 
 	if err != nil {

--- a/honkfish.go
+++ b/honkfish.go
@@ -97,7 +97,7 @@ func honksList() slackResponse {
 
 	var honks []string
 
-	for key, _ := range dictionary {
+	for key := range dictionary {
 		honks = append(honks, key)
 	}
 

--- a/honkfish.go
+++ b/honkfish.go
@@ -6,12 +6,19 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"sort"
 )
 
 type SlackResponse struct {
 	ResponseType string `json:"response_type"`
 	Text         string `json:"text"`
 }
+
+type Alphabetically []string
+
+func (s Alphabetically) Len() int           { return len(s) }
+func (s Alphabetically) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s Alphabetically) Less(i, j int) bool { return len(s[i]) < len(s[j]) }
 
 /*
 	Translation map from honks to the boat's behaviour
@@ -88,8 +95,16 @@ func usageText() SlackResponse {
 func honksList() SlackResponse {
 	formattedHonks := "Honks:"
 
-	for k, v := range dictionary {
-		formattedHonks += fmt.Sprintf("\n_%s_ -> %s", k, v)
+	var honks []string
+
+	for key, _ := range dictionary {
+		honks = append(honks, key)
+	}
+
+	sort.Sort(Alphabetically(honks))
+
+	for _, honk := range honks {
+		formattedHonks += fmt.Sprintf("\n_%s_ -> %s", honk, dictionary[honk])
 	}
 
 	response := SlackResponse{

--- a/honkfish.go
+++ b/honkfish.go
@@ -52,6 +52,10 @@ func requestHandler(w http.ResponseWriter, r *http.Request) {
 		sendResponse(w, usageText())
 	case "usage":
 		sendResponse(w, usageText())
+	case "list":
+		sendResponse(w, honksList())
+	case "all":
+		sendResponse(w, honksList())
 	default:
 		sendResponse(w, translateHonks(userInput))
 	}
@@ -76,6 +80,21 @@ func usageText() SlackResponse {
 	response := SlackResponse{
 		ResponseType: "ephemeral",
 		Text:         "Usage:\n`/honkfish honk pause HONK`\nhonk = short honk\nHONK = long honk\npause = a gap between honks",
+	}
+
+	return response
+}
+
+func honksList() SlackResponse {
+	formattedHonks := "Honks:"
+
+	for k, v := range dictionary {
+		formattedHonks += fmt.Sprintf("\n_%s_ -> %s", k, v)
+	}
+
+	response := SlackResponse{
+		ResponseType: "ephemeral",
+		Text:         formattedHonks,
 	}
 
 	return response

--- a/honkfish.go
+++ b/honkfish.go
@@ -20,17 +20,17 @@ type SlackResponse struct {
 	p = pause between honks
 */
 var dictionary = map[string]string{
-	"honk" 																	: "I am altering my course to STARBOARD",
-	"honk honk" 														: "I am altering my course to PORT",
-	"honk honk honk" 												: "I am going ASTERN",
-	"honk honk honk honk pause honk" 				: "I am turning through 360 degrees to STARBOARD",
-	"honk honk honk honk pause honk honk" 	: "I am turning through 360 degrees to PORT",
-	"honk honk honk honk honk" 							: "I do not understand your intentions, *keep clear*, I doubt whether you are taking sufficient action to avoid a collision",
-	"HONK" 																	: "I am about to get underway, enter the fairway or I am approaching a blind bend",
-	"HONK pause honk pause honk" 						: "I am unable to manoeuvre - not under command",
-	"HONK pause HONK pause honk" 						: "I intend to overtake you on YOUR STARBOARD side",
-	"HONK pause HONK pause honk pause honk" : "I intend to overtake you on YOUR PORT side",
-	"HONK pause honk pause HONK pause honk" : "I agree to be overtaken",
+	"honk":                                "I am altering my course to STARBOARD",
+	"honk honk":                           "I am altering my course to PORT",
+	"honk honk honk":                      "I am going ASTERN",
+	"honk honk honk honk pause honk":      "I am turning through 360 degrees to STARBOARD",
+	"honk honk honk honk pause honk honk": "I am turning through 360 degrees to PORT",
+	"honk honk honk honk honk":            "I do not understand your intentions, *keep clear*, I doubt whether you are taking sufficient action to avoid a collision",
+	"HONK": "I am about to get underway, enter the fairway or I am approaching a blind bend",
+	"HONK pause honk pause honk":            "I am unable to manoeuvre - not under command",
+	"HONK pause HONK pause honk":            "I intend to overtake you on YOUR STARBOARD side",
+	"HONK pause HONK pause honk pause honk": "I intend to overtake you on YOUR PORT side",
+	"HONK pause honk pause HONK pause honk": "I agree to be overtaken",
 }
 
 func main() {


### PR DESCRIPTION
Adds command to list all valid honks and their translations.

Usage `/honkfish list` or `/honkfish all`

Output (truncated):
```
_honk honk_ -> I am altering my course to PORT
_honk honk honk_ -> I am going ASTERN
```